### PR TITLE
Use JSON instead of XML in the API call

### DIFF
--- a/public_html/ime.js
+++ b/public_html/ime.js
@@ -102,7 +102,7 @@ function ime_init1() {
 
 	var url = mw.config.get('wgScriptPath') + '/api.php?format=json&action=query&prop=imageinfo&iiprop=size&titles=' + mw.config.get('wgPageName');
 
-	$.get(url, function(response) {
+	$.get(url, function(data) {
 		if( typeof data.query.pages != "undefined" ) {
 	        	imageProperties = data.query.pages[Object.keys(data.query.pages)[0]];
 			ime_width = imageProperties.imageinfo[0].width;

--- a/public_html/ime.js
+++ b/public_html/ime.js
@@ -100,22 +100,24 @@ function ime_init1() {
 		return;
 	}
 
-	var url = mw.config.get('wgScriptPath') + '/api.php?format=xml&action=query&prop=imageinfo&iiprop=size&titles=' + mw.config.get('wgPageName');
+	var url = mw.config.get('wgScriptPath') + '/api.php?format=json&action=query&prop=imageinfo&iiprop=size&titles=' + mw.config.get('wgPageName');
 
 	$.get(url, function(response) {
-		var iiAttr = response.getElementsByTagName('ii')[0].attributes;
-		ime_width = iiAttr.getNamedItem('width').nodeValue;
-		ime_height = iiAttr.getNamedItem('height').nodeValue;
+		if( typeof data.query.pages != "undefined" ) {
+	        	imageProperties = data.query.pages[Object.keys(data.query.pages)[0]];
+			ime_width = imageProperties.imageinfo[0].width;
+			ime_height = imageProperties.imageinfo[0].height;
 
-		ime_scale = img.width/ime_width;
+			ime_scale = img.width/ime_width;
 
-		// Show 'show ImageMapEdit' button now
-		var a = document.createElement('a');
-		a.id = 'imeLink';
-		a.href = 'javascript:ime_init2()';
-		a.style.display = 'block';
-		a.appendChild(document.createTextNode('ImageMapEdit >'));
-		document.getElementById('file').appendChild(a);
+			// Show 'show ImageMapEdit' button now
+			var a = document.createElement('a');
+			a.id = 'imeLink';
+			a.href = 'javascript:ime_init2()';
+			a.style.display = 'block';
+			a.appendChild(document.createTextNode('ImageMapEdit >'));
+			document.getElementById('file').appendChild(a);
+		}
 	});
 }
 


### PR DESCRIPTION
Using the ?format=xml in older MW versions would cause an PHP error in the result, resulting in an invalid response. 

For example the api returned the following XML:
`<error code="internal_api_error_MWException" info="Exception Caught: Internal error in ApiResult::setElement: Bad parameter" xml:space="preserve" />`

The call will now be executed through json. 