### PR TITLE
Update translations.php

### DIFF
--- a/public_html/translations.php
+++ b/public_html/translations.php
@@ -2,7 +2,8 @@
 
 header('Content-type: text/javascript; encoding=utf8');
 
-$lang = $_GET['lang'];
+$languages_ok = ['en','de','de-formal','it'];
+$lang = in_array($_GET['lang'],$languages_ok) ? $lang : 'en';
 if (!$lang) $lang = 'en';
 
 ?>

--- a/public_html/translations.php
+++ b/public_html/translations.php
@@ -3,8 +3,9 @@
 header('Content-type: text/javascript; encoding=utf8');
 
 $languages_ok = ['en','de','de-formal','it'];
-$lang = in_array($_GET['lang'],$languages_ok) ? $lang : 'en';
-if (!$lang) $lang = 'en';
+
+$lang = $_GET['lang'];
+$lang = in_array($lang,$languages_ok) ? $lang : 'en';
 
 ?>
 /*


### PR DESCRIPTION
$lang parameter needs escaping to avoid xss vulnerabilities. 
Without this, a call to a url .../translations.php?lang=de-THISISTHEPROBLEM are possible.
The proposed new parameter languages_ok lists all the languages available and accepted for user input. 
Kudos to @mwallisch for the hint